### PR TITLE
Remove call to nonEmptyDomain

### DIFF
--- a/packages/core/src/point-cloud/point-cloud.ts
+++ b/packages/core/src/point-cloud/point-cloud.ts
@@ -83,11 +83,6 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
   protected async createScene(): Promise<Scene> {
     return super.createScene().then(async scene => {
       this.scene = scene;
-
-      // load point cloud data extents and data if bounding box not provided
-      const { data, xmin, xmax, ymin, ymax, zmin, zmax } = await getPointCloud(
-        this.options
-      );
       this.attachKeys();
 
       const sceneColors = setSceneColors(this.options.colorScheme as string);
@@ -167,18 +162,21 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
         );
         this.model.metadata = octantMetadata;
       } else {
-        await this.model.init(
-          this.scene,
-          xmin,
-          xmax,
-          ymin,
-          ymax,
-          zmin,
-          zmax,
-          1,
-          this.options.rgbMax || 1.0,
-          data as SparseResult
-        );
+        const pcData = await getPointCloud(this.options);
+        if (pcData) {
+          await this.model.init(
+            this.scene,
+            pcData.xmin,
+            pcData.xmax,
+            pcData.ymin,
+            pcData.ymax,
+            pcData.zmin,
+            pcData.zmax,
+            1,
+            this.options.rgbMax || 1.0,
+            pcData.data as SparseResult
+          );
+        }
       }
 
       // add shader post-processing for EDL
@@ -255,6 +253,7 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
             const ray = camera.getForwardRay();
             const block = this.model.octree.getContainingBlocksByRay(
               ray,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               this.model.maxLevel!
             )[0];
             pickOrigin = block.minPoint.add(

--- a/packages/core/src/point-cloud/utils/tiledb-pc.ts
+++ b/packages/core/src/point-cloud/utils/tiledb-pc.ts
@@ -199,16 +199,6 @@ export async function getPointCloud(options: TileDBPointCloudOptions) {
       zmax = zmax + z;
     }
     return { data, xmin, xmax, ymin, ymax, zmin, zmax };
-  } else {
-    const dom = await getNonEmptyDomain(options);
-    return {
-      xmin: dom[0],
-      xmax: dom[1],
-      ymin: dom[2],
-      ymax: dom[3],
-      zmin: dom[4],
-      zmax: dom[5]
-    };
   }
 }
 


### PR DESCRIPTION
Now we retrieve the sparsity information and client octree bounds from the array metadata we no longer need to make a call to get the non-empty domain. This is useful in general as the data is redundant but also fixes a bug @calexat-123 reported with non-heterogeneous dimensions.