### PR TITLE
Use known blocks before request

### DIFF
--- a/packages/core/src/point-cloud/model/array-model.ts
+++ b/packages/core/src/point-cloud/model/array-model.ts
@@ -383,9 +383,6 @@ class ArrayModel {
             this.pickedBlockCode = pickCode;
             this.renderBlocks = parentBlocks;
             this.isBuffering = false;
-            // restart count to base level as we are going to redraw
-            // particle systems are based on a lru cache, this is just a way of preventing too many points being loaded
-            this.pointCount = this.basePcs.nbParticles;
             this.neighbours = this.octree.getNeighbours(this.pickedBlockCode);
           }
 
@@ -419,11 +416,14 @@ class ArrayModel {
           }
 
           if (block) {
-            const nextPointCount =
-              this.octree.knownBlocks.get(block.mortonNumber) ||
-              this.pointCount;
+            const nextPointCount = this.octree.knownBlocks.get(
+              block.mortonNumber
+            );
 
-            if (nextPointCount <= this.pointBudget) {
+            if (
+              nextPointCount &&
+              this.pointCount + nextPointCount <= this.pointBudget
+            ) {
               this.fetchBlock(block);
             }
           }


### PR DESCRIPTION
This fixes an issue with point count and requesting octant blocks which are known to be `undefined`. This should result in a performance increase for larger arrays.