### PR TITLE
Fix to scrolling notebook up and down when zooming in/out with mouse wheel

### DIFF
--- a/packages/core/src/point-cloud/point-cloud.ts
+++ b/packages/core/src/point-cloud/point-cloud.ts
@@ -114,8 +114,8 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
               this.cameras[this.activeCamera],
               this.cameras[this.activeCamera + 2]
             ];
-            this.scene.activeCameras[0].attachControl(true);
-            this.scene.activeCameras[1].attachControl(true);
+            this.scene.activeCameras[0].attachControl(false);
+            this.scene.activeCameras[1].attachControl(false);
             if (this.model.particleMaterial) {
               this.model.particleMaterial.setShader(
                 this.scene,

--- a/packages/core/src/point-cloud/utils/camera-utils.ts
+++ b/packages/core/src/point-cloud/utils/camera-utils.ts
@@ -101,8 +101,8 @@ export function setCameraLight(
   >();
   cameras.push(camera0, camera1, camera2, camera3);
 
-  cameras[0].attachControl(true);
-  cameras[2].attachControl(true);
+  cameras[0].attachControl(false);
+  cameras[2].attachControl(false);
   scene.activeCameras = [cameras[0], cameras[2]];
 
   // add general lights


### PR DESCRIPTION
@normanb @XanthosXanthopoulos this fixes the notebook issue with the notebook itself scrolling when zooming in/out. Tested with both the storybooks and Jupyter notebooks. I did not notice any issues, but could you confirm that it will not affect the panning as there the below is set and not entirely clear to me why is `true, true` here
`this.cameras[0].attachControl(true, true);`