### PR TITLE
Pickable points with thin instances

### DIFF
--- a/packages/core/src/point-cloud/meshes/thin-point-cloud.ts
+++ b/packages/core/src/point-cloud/meshes/thin-point-cloud.ts
@@ -93,6 +93,9 @@ export class ThinPointsCloudSystem implements IDisposable {
 
     const mesh = new Mesh(this.name, this._scene);
     vertexData.applyToMesh(mesh, false);
+    mesh.isPickable = true;
+    mesh.thinInstanceEnablePicking = true;
+
     this.mesh = mesh;
 
     let mat = material;

--- a/packages/core/src/point-cloud/point-cloud.ts
+++ b/packages/core/src/point-cloud/point-cloud.ts
@@ -18,6 +18,7 @@ import {
   Tags
 } from '@babylonjs/core';
 import { TileDBVisualization } from '../base';
+import { SparseResult } from './model/sparse-result';
 import ArrayModel from './model/array-model';
 import {
   getArrayMetadata,
@@ -36,7 +37,6 @@ import { ArraySchema } from '@tiledb-inc/tiledb-cloud/lib/v1';
 import { SPSHighQualitySplats } from './pipelines/high-quality-splats';
 import { CustomDepthTestMaterialPlugin } from './materials/plugins/customDepthTestPlugin';
 import { LinearDepthMaterialPlugin } from './materials/plugins/linearDepthPlugin';
-import { SparseResult } from './model/sparse-result';
 
 class TileDBPointCloudVisualization extends TileDBVisualization {
   private scene!: Scene;
@@ -313,7 +313,7 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
       let isPanning = false;
 
       // register for onPointerDown as we need the keyboard state as well
-      scene.onPointerDown = evt => {
+      scene.onPointerDown = (evt, pickResult) => {
         if (evt.ctrlKey || evt.shiftKey) {
           const pickResult = scene.pick(scene.pointerX, scene.pointerY);
           if (pickResult) {
@@ -326,6 +326,11 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
             plane = Plane.FromPositionAndNormal(pickOrigin, normal);
             this.cameras[0].detachControl();
             isPanning = true;
+          }
+        } else {
+          if (pickResult.hit) {
+            const p = pickResult.pickedPoint;
+            console.log(p);
           }
         }
       };


### PR DESCRIPTION
We want to use pickable points with thin instances (not SPS which copies the point data). Reviewing this [playground](https://www.babylonjs-playground.com/#RC2IAH#1) and adding the logic to our code gives an example of logging the clicked point to the console. It will need a selection icon in the GUI and a table view, this can be a synchronous request to the server.