### PR TITLE
Invalidation cache strategy

### DIFF
--- a/packages/core/src/point-cloud/model/array-model.ts
+++ b/packages/core/src/point-cloud/model/array-model.ts
@@ -25,7 +25,7 @@ import {
 } from './sparse-result';
 import { ParticleShaderMaterial, TileDBPointCloudOptions } from '../utils';
 import { TileDBWorkerPool } from '../workers';
-import { getQueryDataFromCache } from '../../utils/cache';
+import { clearCache, getQueryDataFromCache } from '../../utils/cache';
 import { ArraySchema } from '@tiledb-inc/tiledb-cloud/lib/v1';
 import { PriorityQueue } from '../utils/priority-queue';
 import { LinearDepthMaterial } from '../materials/linearDepthMaterial';
@@ -78,10 +78,12 @@ class ArrayModel {
   additiveProximityMaterial!: AdditiveProximityMaterial;
   basePointSize = 1;
   visible: Map<number, boolean>;
+  registrationTimestamp?: number;
 
   constructor(
     options: TileDBPointCloudOptions,
-    renderTargets: RenderTargetTexture[]
+    renderTargets: RenderTargetTexture[],
+    timestamp?: number
   ) {
     this.groupName = options.groupName;
     this.namespace = options.namespace;
@@ -96,6 +98,7 @@ class ArrayModel {
     this.edlNeighbours = options.edlNeighbours || 8;
     this.colorScheme = options.colorScheme || 'dark';
     this.pointBudget = options.pointBudget || 500_000;
+    this.registrationTimestamp = timestamp;
 
     if (options.useShader === true) {
       this.useShader = true;
@@ -261,11 +264,24 @@ class ArrayModel {
       if (!this.particleSystems.has(block.mortonNumber)) {
         const queryCacheKey = block.mortonNumber;
         const storeName = `${this.namespace}:${this.groupName}`;
+
         // check indexeddb cache
-        const dataFromCache = await getQueryDataFromCache(
+        let dataFromCache = await getQueryDataFromCache(
           storeName,
           queryCacheKey
         );
+
+        /**
+         * If the index saved doesn't match the array's registration timestamp
+         * we clear cache and unset dataFromCache in order to fetch new data.
+         */
+        if (
+          dataFromCache &&
+          dataFromCache.__timestamp !== this.registrationTimestamp
+        ) {
+          await clearCache(storeName);
+          dataFromCache = undefined;
+        }
         if (dataFromCache) {
           this.loadSystem(dataFromCache);
         } else {
@@ -445,7 +461,8 @@ class ArrayModel {
           bufferSize: this.bufferSize
         } as InitialRequest,
         this.loadSystem.bind(this),
-        this.poolSize
+        this.poolSize,
+        this.registrationTimestamp as number
       );
 
       scene.onBeforeRenderObservable.add((scene: Scene) => {

--- a/packages/core/src/point-cloud/point-cloud.ts
+++ b/packages/core/src/point-cloud/point-cloud.ts
@@ -37,6 +37,7 @@ import { SPSHighQualitySplats } from './pipelines/high-quality-splats';
 import { CustomDepthTestMaterialPlugin } from './materials/plugins/customDepthTestPlugin';
 import { LinearDepthMaterialPlugin } from './materials/plugins/linearDepthPlugin';
 import { SparseResult } from './model/sparse-result';
+import getArrayRegistrationTimestamp from '../utils/getArrayRegistrationTimestamp';
 
 class TileDBPointCloudVisualization extends TileDBVisualization {
   private scene!: Scene;
@@ -206,9 +207,15 @@ class TileDBPointCloudVisualization extends TileDBVisualization {
       if (!this.options.useSPS) {
         this.renderTargets = this.pipeline.initializeRTTs();
       }
-
+      let timestamp;
+      if (this.options.groupName && this.options.namespace) {
+        timestamp = await getArrayRegistrationTimestamp(
+          this.options.namespace,
+          this.options.groupName + '_0'
+        );
+      }
       // initialize ParticleSystem
-      this.model = new ArrayModel(this.options, this.renderTargets);
+      this.model = new ArrayModel(this.options, this.renderTargets, timestamp);
 
       if (this.options.streaming) {
         const [octantMetadata, octreeBounds, conformingBounds, levels] =

--- a/packages/core/src/point-cloud/workers/tiledb.worker.pool.ts
+++ b/packages/core/src/point-cloud/workers/tiledb.worker.pool.ts
@@ -12,6 +12,7 @@ import { MoctreeBlock } from '../octree';
 
 class TileDBWorkerPool {
   private poolSize: number;
+  private indexTimestamp: number;
   private workers: Worker[] = [];
   private callbackFn: (block: MoctreeBlock) => void;
   private mapStatus: Map<string, boolean>;
@@ -21,12 +22,14 @@ class TileDBWorkerPool {
   constructor(
     initRequest: InitialRequest,
     callbackFn: (block: MoctreeBlock) => void,
-    poolSize: number
+    poolSize: number,
+    indexTimestamp: number
   ) {
     this.poolSize = poolSize || 5;
     this.callbackFn = callbackFn;
     this.mapStatus = new Map<string, boolean>();
     this.initRequest = initRequest;
+    this.indexTimestamp = indexTimestamp;
 
     for (let w = 0; w < this.poolSize; w++) {
       const worker = new Worker(new URL('tiledb.worker', import.meta.url), {
@@ -59,7 +62,7 @@ class TileDBWorkerPool {
       const queryCacheKey = block.mortonNumber;
       const storeName = `${this.initRequest.namespace}:${this.initRequest.groupName}`;
       this.callbackFn(block);
-      await writeToCache(storeName, queryCacheKey, block);
+      await writeToCache(storeName, queryCacheKey, block, this.indexTimestamp);
     } else if (m.type === WorkerType.idle) {
       const idleMessage = m as IdleResponse;
       if (this.messageQueue.length > 0) {

--- a/packages/core/src/utils/cache/cache.ts
+++ b/packages/core/src/utils/cache/cache.ts
@@ -46,15 +46,19 @@ export const invalidateKeys = async (storeName: string, bound: number) => {
     await cursor.delete();
   }
 };
-// invalidateKeys('TileDB-Inc:autzen-classified', 1681293670742);
+
 export const writeToCache = async (
   storeName: string,
   key: number,
-  data: any
+  data: any,
+  indexTimestamp = Date.now()
 ) => {
   const db = await getCacheDB(storeName);
-  const now = Date.now();
-  await db.put(storeName, Object.assign(data, { __timestamp: now }), key);
+  await db.put(
+    storeName,
+    Object.assign(data, { __timestamp: indexTimestamp }),
+    key
+  );
 };
 
 export const clearCache = async (storeName: string) => {

--- a/packages/core/src/utils/getArrayRegistrationTimestamp/getArrayRegistrationTimestamp.ts
+++ b/packages/core/src/utils/getArrayRegistrationTimestamp/getArrayRegistrationTimestamp.ts
@@ -1,0 +1,26 @@
+import getTileDBClient from '../getTileDBClient';
+
+const registrationTimestampCache: Record<string, number> = {};
+
+const getArrayRegistrationTimestamp = async (ns: string, arrayName: string) => {
+  const key = `${ns}:${arrayName}`;
+  if (registrationTimestampCache[key]) {
+    return registrationTimestampCache[key];
+  }
+  const client = getTileDBClient();
+  const res = await client.ArrayApi.arrayActivityLog(
+    ns,
+    arrayName,
+    0,
+    undefined,
+    'register'
+  );
+  const [firstLog = {}] = res.data;
+  const date = new Date(firstLog.event_at as string);
+  const timestamp = Number(date);
+  registrationTimestampCache[key] = timestamp;
+
+  return timestamp;
+};
+
+export default getArrayRegistrationTimestamp;

--- a/packages/core/src/utils/getArrayRegistrationTimestamp/index.ts
+++ b/packages/core/src/utils/getArrayRegistrationTimestamp/index.ts
@@ -1,0 +1,3 @@
+import getArrayRegistrationTimestamp from './getArrayRegistrationTimestamp';
+
+export default getArrayRegistrationTimestamp;


### PR DESCRIPTION
Invalidate indexed DB cache data based on the saved index.

- Fetch array activity to get the timestamp the array was created.
- Use that timestamp as an index value.
- When we retrieve data from cache (Cache hit), compare timestamps, if there is a mismatch we clear the cache