### PR TITLE
Change additive render target type depending on webgl extension support

### DIFF
--- a/packages/core/src/point-cloud/pipelines/high-quality-splats.ts
+++ b/packages/core/src/point-cloud/pipelines/high-quality-splats.ts
@@ -8,6 +8,7 @@ import {
   Color4
 } from '@babylonjs/core';
 import { TileDBPointCloudOptions } from '../utils/tiledb-pc';
+import { getWebGLExtension } from '../../utils/webgl_helpers';
 
 export class SPSHighQualitySplats {
   private scene: Scene;
@@ -47,7 +48,9 @@ export class SPSHighQualitySplats {
       {
         generateDepthBuffer: false,
         format: Constants.TEXTUREFORMAT_RGBA,
-        type: Constants.TEXTURETYPE_FLOAT
+        type: getWebGLExtension('EXT_float_blend', this.scene)
+          ? Constants.TEXTURETYPE_FLOAT
+          : Constants.TEXTURETYPE_HALF_FLOAT
       }
     );
     additiveColorRenderTarget.clearColor = new Color4(0.0, 0.0, 0.0, 0.0);

--- a/packages/core/src/utils/webgl_helpers.ts
+++ b/packages/core/src/utils/webgl_helpers.ts
@@ -1,0 +1,11 @@
+import { Scene } from '@babylonjs/core';
+
+export function getWebGLExtension(name: string, scene: Scene): boolean {
+  const ext = scene
+    .getEngine()
+    .getRenderingCanvas()
+    ?.getContext('webgl2')
+    ?.getExtension(name);
+
+  return ext !== undefined && ext !== null;
+}


### PR DESCRIPTION
This PR fixes a rendering bug on iOS (iPhone and iPad) devices that do not support blending with 32bit color components due to lack of support of the `EXT_float_blend` extension after iOS version 15.6