### PR TITLE
Specify asset type

### DIFF
--- a/packages/components/src/GroupPanel.component.svelte
+++ b/packages/components/src/GroupPanel.component.svelte
@@ -35,7 +35,7 @@
   let pages = Math.ceil(filteredGroups.length / itemsPerPage);
   let currentPage = 0;
 
-  function onClick(namespace, assetID) {
+  function onClick(namespace, groupID, arrayID) {
     window.dispatchEvent(
       new CustomEvent(events.BUTTON_CLICK, {
         bubbles: true,
@@ -43,7 +43,8 @@
           id: 'asset_selection',
           props: {
             namespace,
-            assetID
+            groupID,
+            arrayID
           }
         }
       })
@@ -77,7 +78,7 @@
     <ul class="Viewer-GroupSelector__list">
       {#each filteredGroups.slice(currentPage * itemsPerPage, (currentPage + 1) * itemsPerPage) as group}
         <li class="Viewer-GroupSelector__item">
-          <button class="Viewer-GroupSelector__item-content" on:click={() => onClick(group.namespace, group.id)}>
+          <button class="Viewer-GroupSelector__item-content" on:click={() => onClick(group.namespace, group.groupID, group.arrayID)}>
             <div class="Viewer-GroupSelector__item-icon">
               <svg
                 width="32"

--- a/packages/core/src/tile/tileImage.ts
+++ b/packages/core/src/tile/tileImage.ts
@@ -73,14 +73,14 @@ class TileDBTiledImageVisualization extends TileDBVisualization {
         token: this.options.token,
         tiledbEnv: this.options.tiledbEnv,
         namespace: this.options.namespace,
-        assetID: this.options.assetID
+        arrayID: this.options.arrayID,
+        groupID: this.options.groupID
       })) as [ImageMetadata, Attribute[], Dimension[], LevelRecord[]];
 
     this.groupAssets = await getGroupContents({
       token: this.options.token,
       tiledbEnv: this.options.tiledbEnv,
       namespace: this.options.namespace,
-      assetID: this.options.assetID,
       baseGroup: this.options.baseGroup
     });
 
@@ -143,8 +143,8 @@ class TileDBTiledImageVisualization extends TileDBVisualization {
       this.groupAssets,
       (step: number) => this.onZoom(step),
       () => this.clearCache(),
-      (namespace: string, assetID: string) =>
-        this.onAssetSelection(namespace, assetID)
+      (namespace: string, groupID?: string, arrayID?: string) =>
+        this.onAssetSelection(namespace, groupID, arrayID)
     );
 
     this.updateEngineInfo();
@@ -174,7 +174,7 @@ class TileDBTiledImageVisualization extends TileDBVisualization {
 
   private updateEngineInfo() {
     getTileCount(this.levels.map(x => `${x.id}_${this.tileSize}`)).then(
-      tileCount => {
+      (tileCount: number) => {
         const selectedAttribute = this.attributes
           .filter(x => x.visible)[0]
           .type.toLowerCase();
@@ -266,12 +266,17 @@ class TileDBTiledImageVisualization extends TileDBVisualization {
     );
   }
 
-  private onAssetSelection(namespace: string, assetID: string) {
+  private onAssetSelection(
+    namespace: string,
+    groupID?: string,
+    arrayID?: string
+  ) {
     this.scene.getEngine().stopRenderLoop();
 
     this.clearScene();
 
-    this.options.assetID = assetID;
+    this.options.groupID = groupID;
+    this.options.arrayID = arrayID;
     this.options.namespace = namespace;
 
     this.initializeScene().then(() =>

--- a/packages/core/src/tile/types/index.ts
+++ b/packages/core/src/tile/types/index.ts
@@ -4,7 +4,8 @@ import { Attribute, Dimension, AssetMetadata } from '../../types';
 
 export interface TileDBTileImageOptions extends TileDBVisualizationBaseOptions {
   namespace: string;
-  assetID: string;
+  arrayID?: string;
+  groupID?: string;
   baseGroup?: string;
   token: string;
   tiledbEnv?: string;

--- a/packages/core/src/tile/utils/gui-utils.ts
+++ b/packages/core/src/tile/utils/gui-utils.ts
@@ -15,7 +15,11 @@ class TileImageGUI {
   private uiWrapper!: HTMLDivElement;
   private zoomCallback: (step: number) => void;
   private clearCache: () => void;
-  private assetSelectionCallback: (namespace: string, assetID: string) => void;
+  private assetSelectionCallback: (
+    namespace: string,
+    groupID?: string,
+    arrayID?: string
+  ) => void;
 
   private sliderEventHandler;
   private colorEventHandler;
@@ -30,7 +34,11 @@ class TileImageGUI {
     assets: AssetEntry[],
     zoomCallback: (step: number) => void,
     clearCache: () => void,
-    assetSelectionCallback: (namespace: string, assetID: string) => void
+    assetSelectionCallback: (
+      namespace: string,
+      groupID?: string,
+      arrayID?: string
+    ) => void
   ) {
     this.rootElement = rootElement;
     this.tileset = tileset;
@@ -206,7 +214,8 @@ class TileImageGUI {
       case 'asset_selection':
         this.assetSelectionCallback(
           customEvent.detail.props.namespace,
-          customEvent.detail.props.assetID
+          customEvent.detail.props.groupID,
+          customEvent.detail.props.arrayID
         );
         break;
       default:

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,14 +5,16 @@ export interface AssetMetadata {
 export interface AssetEntry {
   namespace: string;
   name: string;
-  id: string;
+  arrayID?: string;
+  groupID?: string;
 }
 
 export interface AssetOptions {
   token: string;
   tiledbEnv?: string;
   namespace: string;
-  assetID: string;
+  arrayID?: string;
+  groupID?: string;
   baseGroup?: string;
 }
 

--- a/packages/react/src/stories/TileImage.stories.tsx
+++ b/packages/react/src/stories/TileImage.stories.tsx
@@ -26,7 +26,8 @@ const Template = () => (
   <TileImageVisualization
     token={token}
     namespace={namespace}
-    assetID={'<array/group ID>'}
+    arrayID={'<array ID>'}
+    //groupID={'<group ID>'}
     width={'100vw'}
     height={'100vh'}
   />


### PR DESCRIPTION
This PR changes the asset type discovery mechanism. Instead of try-catching all possible asset types (array, group) we specify the asset type by providing the appropriate property (`arrayID` or `groupID`) before metadata loading.