### PR TITLE
Add TileDB Uri Support

### DIFF
--- a/packages/core/src/utils/metadata-utils/metadata-utils.test.ts
+++ b/packages/core/src/utils/metadata-utils/metadata-utils.test.ts
@@ -1,0 +1,30 @@
+import { tileDBUriParser } from './metadata-utils';
+
+describe('tileDBUriParser', () => {
+  it('TileDB Uri', () => {
+    const { namespace, id } = tileDBUriParser(
+      'tiledb://namespace/85da399c-26c9-1d3e-1391-4278a76d59fa',
+      'fallback'
+    );
+    expect(namespace).toBe('namespace');
+    expect(id).toBe('85da399c-26c9-1d3e-1391-4278a76d59fa');
+  });
+
+  it('TileDB ID with fallback', () => {
+    const { namespace, id } = tileDBUriParser(
+      '85da399c-26c9-1d3e-1391-4278a76d59fa',
+      'fallback'
+    );
+    expect(namespace).toBe('fallback');
+    expect(id).toBe('85da399c-26c9-1d3e-1391-4278a76d59fa');
+  });
+
+  it('Invalid uri', () => {
+    expect(() => {
+      tileDBUriParser(
+        's3://namespace/85da399c-26c9-1d3e-1391-4278a76d59fa',
+        'fallback'
+      );
+    }).toThrow(Error);
+  });
+});

--- a/packages/core/src/utils/metadata-utils/metadata-utils.ts
+++ b/packages/core/src/utils/metadata-utils/metadata-utils.ts
@@ -23,6 +23,23 @@ import {
 import { GroupContents, Datatype } from '@tiledb-inc/tiledb-cloud/lib/v1';
 import { Vector3 } from '@babylonjs/core';
 
+export function tileDBUriParser(
+  uri: string,
+  fallbackNamespace: string
+): { namespace: string; id: string } {
+  const tokens = uri.split('/');
+
+  if (tokens.length === 1) {
+    return { namespace: fallbackNamespace, id: uri };
+  }
+
+  if (tokens[0] !== 'tiledb:') {
+    throw new Error(`'${uri}' is not a TileDB Uri`);
+  }
+
+  return { namespace: tokens[2], id: tokens[3] };
+}
+
 export async function getGroupContents(
   options: AssetOptions
 ): Promise<AssetEntry[]> {
@@ -35,8 +52,13 @@ export async function getGroupContents(
     return [];
   }
 
+  const { namespace, id: baseGroup } = tileDBUriParser(
+    options.namespace,
+    options.baseGroup
+  );
+
   return await client.groups
-    .getGroupContents(options.namespace, options.baseGroup)
+    .getGroupContents(namespace, baseGroup)
     .then((value: GroupContents) => {
       if (!value.entries) {
         return [];


### PR DESCRIPTION
This PR adds support for aseet TileDB uris to be used instead of asset id. This enables combinations of assets from different namespaces to be used in the same scene.