### PR TITLE
Block selection and zoom control fix

### DIFF
--- a/packages/components/src/PointPanel.component.svelte
+++ b/packages/components/src/PointPanel.component.svelte
@@ -61,7 +61,7 @@
         pointShape: 1,
         pointSize: 4,
         pointBudget: 100_000,
-        quality: 10
+        quality: 40
       };
     })
   };

--- a/packages/core/src/tile/model/point/pointManager.ts
+++ b/packages/core/src/tile/model/point/pointManager.ts
@@ -204,7 +204,7 @@ export class PointManager extends Manager<PointTile> {
         this.pointBudget = event.detail.props.value;
         break;
       case 'quality':
-        this.screenSizeLimit = event.detail.props.value;
+        this.screenSizeLimit = 51 - event.detail.props.value;
         break;
     }
   }
@@ -337,12 +337,12 @@ export class PointManager extends Manager<PointTile> {
     this.blockQueue.insert(rootScore, root);
 
     let points = 0;
-    const blocks = 0;
+    let blocks = 0;
 
     while (
       !this.blockQueue.isEmpty() &&
       points < this.pointBudget &&
-      blocks < 400
+      blocks < 200
     ) {
       const block = this.blockQueue.extractMax().octreeBlock;
 
@@ -386,6 +386,7 @@ export class PointManager extends Manager<PointTile> {
       }
 
       points += block.pointCount || 0;
+      ++blocks;
 
       // Calculate children
       for (let i = 0; i < 8; ++i) {
@@ -449,9 +450,13 @@ export class PointManager extends Manager<PointTile> {
     block: MoctreeBlock,
     viewportRadius: number
   ): number {
-    return Math.max(
-      0,
-      block.boundingInfo.boundingSphere.radiusWorld - viewportRadius + 100
+    // return Math.max(
+    //   0,
+    //   block.boundingInfo.boundingSphere.radiusWorld - viewportRadius + 100
+    // );
+
+    return (
+      (block.boundingInfo.boundingSphere.radiusWorld / viewportRadius) * 100
     );
   }
 

--- a/packages/core/src/tile/utils/camera-utils.ts
+++ b/packages/core/src/tile/utils/camera-utils.ts
@@ -335,7 +335,7 @@ export class CameraManager {
           break;
         case PointerEventTypes.POINTERWHEEL:
           {
-            const delta = (pointerInfo.event as WheelEvent).deltaY / 1500;
+            const delta = -(pointerInfo.event as WheelEvent).deltaY / 1500;
 
             this.zoom = Math.max(
               this.lowerZoomLimit,

--- a/packages/core/src/utils/metadata-utils/metadata-utils.test.ts
+++ b/packages/core/src/utils/metadata-utils/metadata-utils.test.ts
@@ -1,0 +1,30 @@
+import { tileDBUriParser } from './metadata-utils';
+
+describe('tileDBUriParser', () => {
+  it('TileDB Uri', () => {
+    const { namespace, id } = tileDBUriParser(
+      'tiledb://namespace/85da399c-26c9-1d3e-1391-4278a76d59fa',
+      'fallback'
+    );
+    expect(namespace).toBe('namespace');
+    expect(id).toBe('85da399c-26c9-1d3e-1391-4278a76d59fa');
+  });
+
+  it('TileDB ID with fallback', () => {
+    const { namespace, id } = tileDBUriParser(
+      '85da399c-26c9-1d3e-1391-4278a76d59fa',
+      'fallback'
+    );
+    expect(namespace).toBe('fallback');
+    expect(id).toBe('85da399c-26c9-1d3e-1391-4278a76d59fa');
+  });
+
+  it('Invalid uri', () => {
+    expect(() => {
+      tileDBUriParser(
+        's3://namespace/85da399c-26c9-1d3e-1391-4278a76d59fa',
+        'fallback'
+      );
+    }).toThrow(Error);
+  });
+});


### PR DESCRIPTION
This PR changes the point cloud block selection mechanism by using a viewport coverage metric to discard small blocks. It also inverts zoom control direction to be in par with the controls of other viewers.