### PR TITLE
Dark theme text fix

### DIFF
--- a/packages/components/src/misc/InlineSlider.component.svelte
+++ b/packages/components/src/misc/InlineSlider.component.svelte
@@ -31,11 +31,13 @@
     display: flex;
     font-family: Inter, Arial, 'sans-serif';
     font-size: 14px;
+    color: var(--viewer-text-primary);
 
     label {
       min-width: 140px;
       line-height: 25px;
       vertical-align: middle;
+      color: var(--viewer-text-primary);
     }
 
     &__collapsable {

--- a/packages/components/src/misc/Select.component.svelte
+++ b/packages/components/src/misc/Select.component.svelte
@@ -41,6 +41,7 @@
       min-width: 140px;
       line-height: 25px;
       vertical-align: middle;
+      color: var(--viewer-text-primary);
     }
 
     select {


### PR DESCRIPTION
This PR fixes an issue where when dark theme is enabled in TileDB cloud the text in some components matches the background color.