### PR TITLE
SOMA Multiscale image support

### DIFF
--- a/packages/common/src/types/core.ts
+++ b/packages/common/src/types/core.ts
@@ -95,7 +95,9 @@ export type AssetConfig = {
   features?: Feature[];
 };
 
-export type ImageConfig = AssetConfig;
+export type ImageConfig = AssetConfig & {
+  isRegularPyramidalImage?: boolean;
+};
 
 export type GeometryConfig = AssetConfig & {
   /**

--- a/packages/core/src/tile/constants.ts
+++ b/packages/core/src/tile/constants.ts
@@ -2,3 +2,7 @@ export const HIGHLIGHTED_STATE = 1;
 export const SELECTED_STATE = 2;
 export const COLOR_GROUPS = 32;
 export const MAX_CATEGORIES = 192;
+
+export const WIDTH_ALIASES = ['X', 'WIDTH', '_X'];
+export const HEIGHT_ALIASES = ['Y', 'HEIGHT', '_Y'];
+export const CHANNEL_ALIASES = ['C', 'BANDS'];

--- a/packages/core/src/tile/model/3d/3DTileManager.ts
+++ b/packages/core/src/tile/model/3d/3DTileManager.ts
@@ -82,7 +82,7 @@ export class TileManager extends Manager<Tile<string, TDB3DTileContent>> {
         tile.children.push(...result.tiles.children);
 
         for (const child of tile.children) {
-          child.parent = tile;
+          child.parents.push(tile);
         }
       } else if (result.assets) {
         tile.data?.update({

--- a/packages/core/src/tile/model/image/imageContent.ts
+++ b/packages/core/src/tile/model/image/imageContent.ts
@@ -151,10 +151,8 @@ export class ImageContent extends TileContent {
       return;
     }
 
-    if (this.texture) {
-      // The tile is already visible so we need to clear textures to update
-      this.texture.dispose();
-    }
+    this.texture?.dispose();
+    this.material?.dispose(true, true);
 
     this.material = this.scene.getEngine().isWebGPU
       ? ImageShaderMaterialWebGPU(

--- a/packages/core/src/tile/model/point/pointContent.ts
+++ b/packages/core/src/tile/model/point/pointContent.ts
@@ -82,6 +82,7 @@ export class PointTileContent
 
     this.meshes[0]._thinInstanceDataStorage.instancesCount = this.pointCount;
     this.meshes[0].layerMask = this.tile.mask;
+    this.meshes[0].renderingGroupId = 3;
     this.meshes[0].setVerticesBuffer(
       new VertexBuffer(this.scene.getEngine(), data.position, 'loc', {
         size: 3,
@@ -114,6 +115,7 @@ export class PointTileContent
       this.meshes[0].setBoundingInfo(this.tile.boundingInfo);
       this.meshes[0].material = this.material;
       this.meshes[0].layerMask = this.tile.mask;
+      this.meshes[0].renderingGroupId = 3;
     }
 
     const vertexData = new VertexData();

--- a/packages/core/src/tile/model/tile.ts
+++ b/packages/core/src/tile/model/tile.ts
@@ -64,9 +64,9 @@ export class Tile<T, C extends TileContent = TileContent> {
   public children: Array<Tile<T, C>>;
 
   /**
-   * THe parent of the tile or undefined if the tile is the tileset root.
+   * The parents of the tile or empty if the tile is the tileset root.
    */
-  public parent?: Tile<T, C>;
+  public parents: Tile<T, C>[];
 
   /**
    * The tile content.
@@ -103,7 +103,7 @@ export class Tile<T, C extends TileContent = TileContent> {
     this.children = [];
     this.content = [];
     this.index = [];
-    this.parent = undefined;
+    this.parents = [];
     this.tilingScheme = TilingScheme.NONE;
     this.geometricError = 0;
     this.state = TileState.HIDDEN;

--- a/packages/core/src/tile/tileImage.ts
+++ b/packages/core/src/tile/tileImage.ts
@@ -132,13 +132,16 @@ export class TileDBTileImageVisualization extends TileDBVisualization {
     }
 
     this.updateLoadingScreen('Loading image asset metadata', true);
-    this.imageMetadata = await getImageMetadata({
-      token: this.options.token,
-      tiledbEnv: this.options.tiledbEnv,
-      namespace: imageNamespace,
-      arrayID: imageArrayID,
-      groupID: imageGroupID
-    });
+    this.imageMetadata = await getImageMetadata(
+      {
+        token: this.options.token,
+        tiledbEnv: this.options.tiledbEnv,
+        namespace: imageNamespace,
+        arrayID: imageArrayID,
+        groupID: imageGroupID
+      },
+      this.options.sceneConfig?.imageConfigs?.[0]
+    );
 
     if (this.options.defaultChannels) {
       const defaultAttribute = this.imageMetadata.attributes.filter(

--- a/packages/core/src/tile/types/index.ts
+++ b/packages/core/src/tile/types/index.ts
@@ -72,6 +72,24 @@ export interface LevelRecord {
   axesMapping: Map<string, Array<string>>;
 }
 
+export interface SOMAMultiscaleImageAssetMetadataRaw extends AssetMetadata {
+  soma_coordinate_space: string;
+  soma_encoding_version: number;
+  soma_multiscale_image_schema: string;
+}
+
+export interface SOMAMultiscaleImageAssetMetadata {
+  soma_coordinate_space: { name: string; units: string; scale?: number }[];
+  soma_encoding_version: number;
+  soma_multiscale_image_schema: {
+    name: string;
+    image_type: string;
+    shape: number[];
+    datatype: string;
+    axis_names: string[];
+  };
+}
+
 export interface BiomedicalAssetMetadata extends AssetMetadata {
   fmt_version: number;
   metadata?: string;

--- a/packages/core/src/tile/utils/picking-tool.ts
+++ b/packages/core/src/tile/utils/picking-tool.ts
@@ -185,9 +185,6 @@ export class PickingTool {
           for (const tile of manager.visibleTiles.values()) {
             if (pickingRay.intersectsBox(tile.boundingInfo.boundingBox)) {
               tiles.push(tile);
-
-              console.log(tile.id);
-
               const result = tile.data?.intersector?.intersectRay(pickingRay);
 
               if (!result) {

--- a/packages/core/src/tile/worker/loaders/imageLoader.ts
+++ b/packages/core/src/tile/worker/loaders/imageLoader.ts
@@ -38,9 +38,10 @@ export async function imageRequest(
             return 'C';
           }
         });
-  if (metadata.implicitChannel) {
+  if (metadata.implicitChannel && !metadata.isWebPCompressed) {
     sourceAxes.unshift('C');
   }
+
   const axes = new Axes(sourceAxes, ['C', 'Y', 'X']);
   const width = payload.region[0].max - payload.region[0].min;
   const height = payload.region[1].max - payload.region[1].min;
@@ -202,7 +203,6 @@ export async function imageRequest(
     } catch (e) {
       console.log(e);
       throw new Error('Request cancelled by the user');
-      return;
     }
 
     const shape: number[] = [];
@@ -210,9 +210,17 @@ export async function imageRequest(
     for (const axis of sourceAxes) {
       switch (axis) {
         case 'X':
+          shape.push(
+            calculatedRanges.get(payload.region[0].dimension)![1] -
+              calculatedRanges.get(payload.region[0].dimension)![0] +
+              1
+          );
+          break;
         case 'Y':
           shape.push(
-            calculatedRanges.get(axis)![1] - calculatedRanges.get(axis)![0] + 1
+            calculatedRanges.get(payload.region[1].dimension)![1] -
+              calculatedRanges.get(payload.region[1].dimension)![0] +
+              1
           );
           break;
         case 'C':

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -8,11 +8,13 @@ export type TDBNonEmptyDomain = {
 
 export enum DatasetType {
   BIOIMG = 'bioimg',
-  RASTER = 'raster'
+  RASTER = 'raster',
+  SOMA_MULTISCALE_IMAGE = 'SOMAMultiscaleImage'
 }
 
 export interface AssetMetadata {
   dataset_type?: DatasetType;
+  soma_object_type?: DatasetType;
 }
 
 export interface AssetEntry {

--- a/packages/core/src/utils/metadata-utils/3DTiles/3DTileLoader.ts
+++ b/packages/core/src/utils/metadata-utils/3DTiles/3DTileLoader.ts
@@ -136,7 +136,7 @@ export function extractBVH(
     tile.geometricError =
       data.geometricError /
       getErrorScaling(data.boundingVolume, tile.boundingInfo);
-    tile.parent = parent;
+    tile.parents.push(parent!);
 
     parent?.children.push(tile);
     tiles.push(tile);

--- a/packages/core/src/utils/metadata-utils/parser.ts
+++ b/packages/core/src/utils/metadata-utils/parser.ts
@@ -1,0 +1,16 @@
+import {
+  SOMAMultiscaleImageAssetMetadata,
+  SOMAMultiscaleImageAssetMetadataRaw
+} from '../../tile';
+
+export function toSOMAMultiscaleImageMetadata(
+  assetMetadata: SOMAMultiscaleImageAssetMetadataRaw
+): SOMAMultiscaleImageAssetMetadata {
+  return {
+    soma_coordinate_space: JSON.parse(assetMetadata.soma_coordinate_space),
+    soma_encoding_version: assetMetadata.soma_encoding_version,
+    soma_multiscale_image_schema: JSON.parse(
+      assetMetadata.soma_multiscale_image_schema
+    )
+  };
+}

--- a/packages/core/src/utils/metadata-utils/pointcloud-metadata-utils.ts
+++ b/packages/core/src/utils/metadata-utils/pointcloud-metadata-utils.ts
@@ -302,17 +302,17 @@ function constructPointCloudTileset(
       transformation
     );
 
-    tile.parent =
+    tile.parents =
       lod === 0
-        ? undefined
-        : tileDictionary.get(encode3D(x / 2, y / 2, z / 2, lod - 1));
-    tile.parent?.children.push(tile);
-    if (tile.parent) {
-      tile.parent.geometricError = Math.max(
+        ? []
+        : [tileDictionary.get(encode3D(x / 2, y / 2, z / 2, lod - 1))!];
+    tile.parents.forEach(x => {
+      x.children.push(tile);
+      x.geometricError = Math.max(
         Math.abs(tileExtents.x),
         Math.abs(tileExtents.z)
       );
-    }
+    });
     tileDictionary.set(tile.index[0], tile);
   }
 

--- a/packages/core/src/utils/metadata-utils/soma-metadata.ts
+++ b/packages/core/src/utils/metadata-utils/soma-metadata.ts
@@ -1,0 +1,233 @@
+import { ArraySchema } from '@tiledb-inc/tiledb-cloud/lib/v1';
+import {
+  Channel,
+  ImageLoaderMetadata,
+  ImageMetadata,
+  SOMAMultiscaleImageAssetMetadata
+} from '../../tile';
+import { getQueryDataFromCache, writeToCache } from '../cache';
+import { AssetOptions, Dimension, Domain } from '../../types';
+import getTileDBClient from '../getTileDBClient';
+import {
+  constructImageTileset,
+  getColor,
+  getDomain,
+  getImageDomain,
+  getNumericLimits
+} from './metadata-utils';
+import { Attribute, ImageConfig } from '@tiledb-inc/viz-common';
+import { MathArray, matrix, Matrix } from 'mathjs';
+
+export async function getSOMAMultiscaleImageMetadata(
+  options: AssetOptions,
+  metadata: SOMAMultiscaleImageAssetMetadata,
+  uris: string[],
+  config?: ImageConfig
+): Promise<ImageMetadata> {
+  const client = getTileDBClient({
+    ...(options.token ? { apiKey: options.token } : {}),
+    ...(options.tiledbEnv ? { basePath: options.tiledbEnv } : {})
+  });
+
+  if (!options.groupID) {
+    throw new Error('SOMAMUltiscaleImage should be a group');
+  }
+
+  let schemas: ArraySchema[] | undefined = await getQueryDataFromCache(
+    options.groupID,
+    'schemas'
+  );
+
+  if (!schemas) {
+    schemas = await Promise.all(
+      uris.map(x => {
+        return client.ArrayApi.getArray(
+          options.namespace,
+          x,
+          'application/json'
+        ).then(y => {
+          const schema = y.data as ArraySchema;
+          schema.uri = x;
+
+          return schema;
+        });
+      })
+    );
+
+    await writeToCache(options.groupID, 'schemas', schemas);
+  }
+
+  const aliases: string[] = [
+    schemas[0].domain.dimensions[
+      metadata.soma_multiscale_image_schema.image_type.indexOf('X')
+    ].name ?? '',
+    schemas[0].domain.dimensions[
+      metadata.soma_multiscale_image_schema.image_type.indexOf('Y')
+    ].name ?? '',
+    schemas[0].domain.dimensions[
+      metadata.soma_multiscale_image_schema.image_type.indexOf('C')
+    ].name ?? ''
+  ];
+
+  const loaderMetadata: Map<string, ImageLoaderMetadata> = new Map(
+    schemas.map(x => {
+      return [
+        x.uri ?? '',
+        {
+          schema: x,
+          domain: x.domain.dimensions
+            .filter(dim => {
+              return (
+                dim.name === aliases[0] ||
+                dim.name === aliases[1] ||
+                dim.name === aliases[2]
+              );
+            })
+            .map(x => {
+              const domain = getDomain(x.domain);
+              return {
+                name: x.name ?? '',
+                type: x.type,
+                min: domain[0],
+                max: domain[1]
+              } as Domain;
+            }),
+          implicitChannel: !x.domain.dimensions.some(
+            dim => dim.name === aliases[2]
+          ),
+          isWebPCompressed: x.attributes.some(y =>
+            // @ts-expect-error Filter type does not match the type returned from REST
+            y.filterPipeline.filters?.some(z => z.type === 'WEBP')
+          ),
+          dimensions: x.domain.dimensions.map(y => y.name ?? '')
+        } as ImageLoaderMetadata
+      ];
+    })
+  );
+
+  // All arrays of the image group should have the same attributes
+  // so we only need to parse the first one
+  const attributes = schemas[0].attributes.map(x => {
+    return {
+      name: x.name,
+      type: x.type,
+      visible: false
+    } as Attribute;
+  });
+  attributes[0].visible = true;
+
+  const dimensions = schemas[0].domain.dimensions
+    .filter(x => {
+      return (
+        (x.name ?? '') !== aliases[0] &&
+        (x.name ?? '') !== aliases[1] &&
+        (x.name ?? '') !== aliases[2]
+      );
+    })
+    .map(x => {
+      const domain = getDomain(x.domain);
+      return {
+        name: x.name ?? '',
+        type: x.type,
+        value: domain[0],
+        min: domain[0],
+        max: domain[1]
+      } as Dimension;
+    });
+
+  // Extract the image extends from each array
+  const extents = schemas
+    .map(x => {
+      return getImageDomain(x, aliases);
+    })
+    .sort(
+      (
+        a: { width: [number, number]; height: [number, number] },
+        b: { width: [number, number]; height: [number, number] }
+      ) => {
+        return a.width[1] - a.width[0] + 1 - (b.width[1] - b.width[0] + 1);
+      }
+    );
+
+  const tilesetRoot = constructImageTileset(extents, schemas, aliases, config);
+
+  // Scale the transformation matrix to express the conversion
+  // from level 0 instead of max level
+  const scale = Math.round(
+    (extents.at(-1)!.width[1] - extents.at(-1)!.width[0] + 1) /
+      (extents[0].width[1] - extents[0].width[0] + 1)
+  );
+
+  const channelCount =
+    metadata.soma_multiscale_image_schema.shape[
+      metadata.soma_multiscale_image_schema.image_type.indexOf('C')
+    ];
+
+  const channels = new Map(
+    schemas[0].attributes.map(attribute => {
+      return [
+        attribute.name,
+        new Array(channelCount).fill(undefined).map<Channel>((_, index) => {
+          const { min, max } = getNumericLimits(attribute.type);
+          return {
+            name: `Channel ${index}`,
+            color: getColor(index),
+            id: `Channel_${index}`,
+            min: min,
+            max: max,
+            visible: true,
+            intensity: max
+          };
+        })
+      ];
+    })
+  );
+
+  return {
+    id: options.groupID,
+    namespace: options.namespace,
+    name: metadata.soma_multiscale_image_schema.name,
+    root: tilesetRoot,
+    uris: uris,
+    channels: channels,
+    attributes: attributes,
+    extraDimensions: dimensions,
+    crs: undefined,
+    pixelToCRS: getTransformationMatrix(metadata, scale),
+    loaderMetadata: loaderMetadata
+  } as ImageMetadata;
+}
+
+function getTransformationMatrix(
+  metadata: SOMAMultiscaleImageAssetMetadata,
+  scale: number
+): Matrix | undefined {
+  const defaultScale =
+    metadata.soma_coordinate_space.find(x => x.name.toLowerCase() === 'x')
+      ?.scale ?? 1;
+
+  return matrix([
+    [
+      (metadata.soma_coordinate_space.find(x => x.name.toLowerCase() === 'x')
+        ?.scale ?? defaultScale) * scale,
+      0,
+      0,
+      0
+    ],
+    [
+      0,
+      (metadata.soma_coordinate_space.find(x => x.name.toLowerCase() === 'y')
+        ?.scale ?? defaultScale) * scale,
+      0,
+      0
+    ],
+    [
+      0,
+      0,
+      (metadata.soma_coordinate_space.find(x => x.name.toLowerCase() === 'z')
+        ?.scale ?? defaultScale) * scale,
+      0
+    ],
+    [0, 0, 0, 1]
+  ] as MathArray);
+}


### PR DESCRIPTION
This PR adds experimental support for `SOMAMultiscaleImage` TileDB assets. Also

- Support non power of 2 pyramidal images
- Support rendering tilesets represented by DAGs instead of trees
