### PR TITLE
Wait loading screen initialization

### DIFF
--- a/packages/core/src/utils/ui-helpers.ts
+++ b/packages/core/src/utils/ui-helpers.ts
@@ -1,0 +1,20 @@
+export async function waitUntilElementVisible(
+  id: string,
+  timeout = 1000,
+  step = 100
+): Promise<boolean> {
+  let counter = 0;
+
+  return new Promise(resolve => {
+    const intervalID = setInterval(() => {
+      counter += step;
+      if (document.getElementById(id)) {
+        resolve(true);
+        clearInterval(intervalID);
+      } else if (counter >= timeout) {
+        resolve(false);
+        clearInterval(intervalID);
+      }
+    }, step);
+  });
+}


### PR DESCRIPTION
In rare occasions the loading screen is not initialized when the engine messages it for hiding. The mechanism awaits until the DOM is updated and then initializes the rest of the application.